### PR TITLE
Support payex invoice in direct model

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ PayEx.default_currency = 'SEK'
 my_order_id = 'c704acc45a4bec4c8cd50b73fb01a7c7'
 
 # Credit card example:
-payment_url = PayEx::Redirect.initialize!
+payment_url = PayEx.initialize!
   price: 14900, # (in cents)
   order_id: my_order_id,
   product_number: '123456',
@@ -33,7 +33,7 @@ payment_url = PayEx::Redirect.initialize!
   cancel_url: 'http://example.com/payex-cancel'
 
 # Swish example:
-payment_url = PayEx::Redirect.initialize!
+payment_url = PayEx.initialize!
   price: 14900, # (in cents)
   order_id: my_order_id,
   product_number: '123456',

--- a/lib/payex.rb
+++ b/lib/payex.rb
@@ -12,6 +12,29 @@ module PayEx
   attr_accessor :encryption_key
   attr_accessor :default_currency
 
+  def initialize!(params)
+    PayEx::PxOrder.Initialize8(
+      accountNumber: params[:account_number],
+      purchaseOperation: params[:purchase_operation],
+      price: params[:price],
+      priceArgList: params[:price_arg_list],
+      currency: params[:currency],
+      vat: params[:vat],
+      orderID: params[:order_id],
+      productNumber: params[:product_number],
+      description: params[:description],
+      clientIPAddress: params[:client_ip_address],
+      clientIdentifier: params[:client_identifier],
+      additionalValues: params[:additional_values],
+      externalID: params[:external_id],
+      returnUrl: params[:return_url],
+      view: params[:view],
+      agreementRef: params[:agreement_ref],
+      cancelUrl: params[:cancel_url],
+      clientLanguage: params[:client_language]
+    )
+  end
+
   def account_number!
     account_number or fail 'Please set PayEx.account_number'
   end
@@ -30,4 +53,5 @@ class PayEx::Error::CardDeclined < PayEx::Error; end
 
 require 'payex/api'
 require 'payex/api/pxorder'
+require 'payex/direct'
 require 'payex/redirect'

--- a/lib/payex.rb
+++ b/lib/payex.rb
@@ -1,7 +1,7 @@
 module PayEx
   extend self
 
-  TEST_URL = 'https://test-external.payex.com'
+  TEST_URL = 'https://external.externaltest.payex.com'
   LIVE_URL = 'https://external.payex.com'
 
   attr_accessor :base_url

--- a/lib/payex/api.rb
+++ b/lib/payex/api.rb
@@ -30,7 +30,7 @@ module PayEx::API
   end
 
   def invoke_raw! wsdl, name, body
-    Savon.client(wsdl: wsdl).call(name, soap_action: false, message: body).body
+    Savon.client(wsdl: wsdl, ssl_verify_mode: :none).call(name, soap_action: false, message: body).body
   end
 
   def signed_hash(string)

--- a/lib/payex/api.rb
+++ b/lib/payex/api.rb
@@ -30,7 +30,7 @@ module PayEx::API
   end
 
   def invoke_raw! wsdl, name, body
-    Savon.client(wsdl: wsdl, ssl_verify_mode: :none).call(name, soap_action: false, message: body).body
+    Savon.client(wsdl: wsdl).call(name, soap_action: false, message: body).body
   end
 
   def signed_hash(string)

--- a/lib/payex/api/pxorder.rb
+++ b/lib/payex/api/pxorder.rb
@@ -92,4 +92,77 @@ module PayEx::PxOrder
       }
     }
   end
+
+  def PurchaseInvoicePrivate(params)
+    PayEx::API.invoke! wsdl, :purchase_invoice_private, params, {
+      'accountNumber' => {
+        signed: true,
+        default: proc { PayEx.account_number! }
+      },
+      'orderRef' => {
+        signed: true
+      },
+      'customerRef' => {
+        signed: true
+      },
+      'customerName' => {
+        signed: true
+      },
+      'streetAddress' => {
+        signed: true
+      },
+      'coAddress' => {
+        signed: true
+      },
+      'postalCode' => {
+        signed: true
+      },
+      'city' => {
+        signed: true
+      },
+      'country' => {
+        signed: true
+      },
+      'socialSecurityNumber' => {
+        signed: true
+      },
+      'phoneNumber' => {
+        signed: true
+      },
+      'email' => {
+        signed: true
+      },
+      'productCode' => {
+        signed: true,
+        default: ''
+      },
+      'creditcheckRef' => {
+        signed: true,
+        default: ''
+      },
+      'mediaDistribution' => {
+        signed: true,
+        format: Integer
+      },
+      'invoiceText' => {
+        signed: true
+      },
+      'invoiceDate' => {
+        signed: true,
+        default: Time.now.strftime('%Y-%m-%d')
+      },
+      'invoiceDueDays' => {
+        signed: true,
+        default: 14
+      },
+      'invoiceNumber' => {
+        signed: true,
+        format: Integer
+      },
+      'invoiceLayout' => {
+        signed: true,
+        default: ''
+      }
+    }
+  end
 end

--- a/lib/payex/direct.rb
+++ b/lib/payex/direct.rb
@@ -1,0 +1,42 @@
+module PayEx::Direct
+  extend self
+
+  def purchase_invoice_private!(params)
+    response = PayEx::PxOrder.PurchaseInvoicePrivate(
+      accountNumber: params[:account_number],
+      orderRef: params[:order_ref],
+      customerRef: params[:customer_ref],
+      customerName: params[:customer_name],
+      streetAddress: params[:street_address],
+      coAddress: params[:co_address],
+      postalCode: params[:postal_code],
+      city: params[:city],
+      country: params[:country],
+      socialSecurityNumber: params[:social_security_number],
+      phoneNumber: params[:phone_number],
+      email: params[:email],
+      productCode: params[:product_code],
+      creditcheckRef: params[:creditcheck_ref],
+      mediaDistribution: params[:media_distribution],
+      invoiceText: params[:invoice_text],
+      invoiceDate: params[:invoice_date],
+      invoiceDueDays: params[:invoice_due_days],
+      invoiceNumber: params[:invoice_number],
+      invoiceLayout: params[:invoice_layout]
+    )
+
+    status = response[:transaction_status]
+    status = PayEx::API.parse_transaction_status(status)
+
+    case status
+    when :sale, :authorize
+      error = nil
+    when :initialize
+      error = PayEx::Error.new('Transaction not completed')
+    else
+      error = PayEx::Error.new('Transaction failed')
+    end
+
+    [response[:order_id], error, response]
+  end
+end

--- a/lib/payex/redirect.rb
+++ b/lib/payex/redirect.rb
@@ -1,30 +1,6 @@
 module PayEx::Redirect
   extend self
 
-  def initialize!(params)
-    response = PayEx::PxOrder.Initialize8(
-      accountNumber: params[:account_number],
-      purchaseOperation: params[:purchase_operation],
-      price: params[:price],
-      priceArgList: params[:price_arg_list],
-      currency: params[:currency],
-      vat: params[:vat],
-      orderID: params[:order_id],
-      productNumber: params[:product_number],
-      description: params[:description],
-      clientIPAddress: params[:client_ip_address],
-      clientIdentifier: params[:client_identifier],
-      additionalValues: params[:additional_values],
-      externalID: params[:external_id],
-      returnUrl: params[:return_url],
-      view: params[:view],
-      agreementRef: params[:agreement_ref],
-      cancelUrl: params[:cancel_url],
-      clientLanguage: params[:client_language]
-    )
-    response[:redirect_url]
-  end
-
   def complete!(id)
     response = PayEx::PxOrder.Complete(orderRef: id)
 

--- a/spec/direct_spec.rb
+++ b/spec/direct_spec.rb
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+require 'payex'
+require 'spec_helper'
+require 'savon/mock/spec_helper'
+
+describe PayEx::Direct do
+  include Savon::SpecHelper
+
+  before(:all) { savon.mock!   }
+  after(:all)  { savon.unmock! }
+
+  describe :purchase_invoice_private! do
+    def invoke_purchase_invoice_private! response_fixture_file
+      expected = {
+        'accountNumber' => PAYEX_ACCOUNT_NUMBER,
+        'orderRef' => SAMPLE_ORDER_REF,
+        'customerRef' => '1000',
+        'customerName' => 'John Doe',
+        'streetAddress' => 'Test',
+        'coAddress' => '',
+        'postalCode' => '12345',
+        'city' => 'Test',
+        'country' => 'SE',
+        'socialSecurityNumber' => '197610277373',
+        'phoneNumber' => '0733123456',
+        'email' => 'test@example.com',
+        'productCode' => SAMPLE_PRODUCT_NUMBER,
+        'creditcheckRef' => '',
+        'mediaDistribution' => 1,
+        'invoiceText' => 'Test',
+        'invoiceDate' => '2017-10-27',
+        'invoiceDueDays' => 14,
+        'invoiceNumber' => 1000,
+        'invoiceLayout' => ''
+      }
+
+      expected['hash'] = PayEx::API.signed_hash(expected.values.join)
+      response_fixture = File.read("spec/fixtures/purchase_invoice_private/#{response_fixture_file}.xml")
+      savon.expects(:purchase_invoice_private).with(message: expected).returns(response_fixture)
+      PayEx::Direct.purchase_invoice_private!(
+        order_ref: expected.fetch('orderRef'),
+        customer_ref: expected.fetch('customerRef'),
+        customer_name: expected.fetch('customerName'),
+        street_address: expected.fetch('streetAddress'),
+        co_address: expected.fetch('coAddress'),
+        postal_code: expected.fetch('postalCode'),
+        city: expected.fetch('city'),
+        country: expected.fetch('country'),
+        social_security_number: expected.fetch('socialSecurityNumber'),
+        phone_number: expected.fetch('phoneNumber'),
+        email: expected.fetch('email'),
+        product_code: expected.fetch('productCode'),
+        creditcheck_ref: expected.fetch('creditcheckRef'),
+        media_distribution: expected.fetch('mediaDistribution'),
+        invoice_text: expected.fetch('invoiceText'),
+        invoice_date: expected.fetch('invoiceDate'),
+        invoice_due_days: expected.fetch('invoiceDueDays'),
+        invoice_number: expected.fetch('invoiceNumber'),
+        invoice_layout: expected.fetch('invoiceLayout')
+      )
+    end
+
+    example 'successful purchase' do
+      order_id, error, data = invoke_purchase_invoice_private! :purchase_invoice_private_ok
+      order_id.should == SAMPLE_ORDER_ID
+      error.should == nil
+    end
+
+    example 'unexpected failure' do
+      order_id, error, data = invoke_purchase_invoice_private! :purchase_invoice_private_failed
+      order_id.should == SAMPLE_ORDER_ID
+      error.should be_a PayEx::Error
+    end
+  end
+end

--- a/spec/fixtures/complete/complete_declined.xml
+++ b/spec/fixtures/complete/complete_declined.xml
@@ -23,8 +23,8 @@
             <orderStatus>0</orderStatus>
             <transactionRef>6d0b1a8e7ab2480583b32f52dba782fe</transactionRef>
             <transactionNumber>1024377</transactionNumber>
-            <orderId>SAMPLEORDERID0001</orderId>
-            <productId>SAMPLEPRODUCTNUMBER0001</productId>
+            <orderId>ORDERID1000</orderId>
+            <productId>PRODUCTNUMBER1000</productId>
             <paymentMethod>VISA</paymentMethod>
             <amount>12300</amount>
             <alreadyCompleted>False</alreadyCompleted>
@@ -35,7 +35,7 @@
               <transactionThirdPartyError>CARD_DECLINED</transactionThirdPartyError>
             </errorDetails>
             <clientAccount>0</clientAccount>
-            <productNumber>SAMPLEPRODUCTNUMBER0001</productNumber>
+            <productNumber>PRODUCTNUMBER1000</productNumber>
             <clientGsmNumber />
             <transactionFailedReason />
             <BankHash>00000001-4581-0903-5682-000000000000</BankHash>

--- a/spec/fixtures/complete/complete_ok.xml
+++ b/spec/fixtures/complete/complete_ok.xml
@@ -23,14 +23,14 @@
             <orderStatus>0</orderStatus>
             <transactionRef>6d0b1a8e7ab2480583b32f52dba782fe</transactionRef>
             <transactionNumber>1024377</transactionNumber>
-            <orderId>SAMPLEORDERID0001</orderId>
-            <productId>SAMPLEPRODUCTNUMBER0001</productId>
+            <orderId>ORDERID1000</orderId>
+            <productId>PRODUCTNUMBER1000</productId>
             <paymentMethod>VISA</paymentMethod>
             <amount>12300</amount>
             <alreadyCompleted>False</alreadyCompleted>
             <Csid>00000001-4581-0903-5682-000000000000</Csid>
             <clientAccount>0</clientAccount>
-            <productNumber>SAMPLEPRODUCTNUMBER0001</productNumber>
+            <productNumber>PRODUCTNUMBER1000</productNumber>
             <clientGsmNumber />
             <BankHash>00000001-4581-0903-5682-000000000000</BankHash>
             <AuthenticatedWith>Y</AuthenticatedWith>

--- a/spec/fixtures/purchase_invoice_private/purchase_invoice_private_failed.xml
+++ b/spec/fixtures/purchase_invoice_private/purchase_invoice_private_failed.xml
@@ -3,14 +3,14 @@
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <soap:Body>
-    <CompleteResponse xmlns="http://external.payex.com/PxOrder/">
-      <CompleteResult>
+    <PurchaseInvoicePrivateResponse xmlns="http://external.payex.com/PxOrder/">
+      <PurchaseInvoicePrivateResult>
         <![CDATA[
           <?xml version="1.0" encoding="utf-8" ?>
           <payex>
             <header name="Payex Header v1.0">
-              <id>dd473e0a40f54596b6db441b34bf54d9</id>
-              <date>2012-09-26 14:08:09</date>
+              <id>a92a59abea034ba3afacdf2f03d4710d</id>
+              <date>2017-10-27 07:15:43</date>
             </header>
             <status>
               <code>OK</code>
@@ -18,35 +18,24 @@
               <errorCode>OK</errorCode>
               <paramName />
               <thirdPartyError />
+              <thirdPartySubError />
             </status>
             <transactionStatus>5</transactionStatus>
-            <orderStatus>0</orderStatus>
-            <transactionRef>6d0b1a8e7ab2480583b32f52dba782fe</transactionRef>
-            <transactionNumber>1024377</transactionNumber>
+            <transactionRef>8f1e5d836a344d06874ab205978e54dd</transactionRef>
+            <transactionNumber>16207900</transactionNumber>
+            <pending>false</pending>
             <orderId>ORDERID1000</orderId>
             <productId>PRODUCTNUMBER1000</productId>
-            <paymentMethod>VISA</paymentMethod>
-            <amount>12300</amount>
-            <alreadyCompleted>False</alreadyCompleted>
-            <Csid>00000001-4581-0903-5682-000000000000</Csid>
+            <paymentMethod>INVOICE</paymentMethod>
+            <productNumber>PRODUCTNUMBER1000</productNumber>
             <errorDetails>
               <transactionErrorCode>Error_Generic</transactionErrorCode>
               <transactionErrorDescription>Accomplish3rdParty</transactionErrorDescription>
               <transactionThirdPartyError>9098</transactionThirdPartyError>
             </errorDetails>
-            <clientAccount>0</clientAccount>
-            <productNumber>PRODUCTNUMBER1000</productNumber>
-            <clientGsmNumber />
-            <transactionFailedReason />
-            <BankHash>00000001-4581-0903-5682-000000000000</BankHash>
-            <AuthenticatedWith>N</AuthenticatedWith>
-            <AuthenticatedStatus />
-            <maskedNumber>45**********5682</maskedNumber>
-            <fraudData>false</fraudData>
-            <pending>false</pending>
           </payex>
         ]]>
-      </CompleteResult>
-    </CompleteResponse>
+      </PurchaseInvoicePrivateResult>
+    </PurchaseInvoicePrivateResponse>
   </soap:Body>
 </soap:Envelope>

--- a/spec/fixtures/purchase_invoice_private/purchase_invoice_private_ok.xml
+++ b/spec/fixtures/purchase_invoice_private/purchase_invoice_private_ok.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body>
+    <PurchaseInvoicePrivateResponse xmlns="http://external.payex.com/PxOrder/">
+      <PurchaseInvoicePrivateResult>
+        <![CDATA[
+          <?xml version="1.0" encoding="utf-8" ?>
+          <payex>
+            <header name="Payex Header v1.0">
+              <id>a92a59abea034ba3afacdf2f03d4710d</id>
+              <date>2017-10-27 07:15:43</date>
+            </header>
+            <status>
+              <code>OK</code>
+              <description>OK</description>
+              <errorCode>OK</errorCode>
+              <paramName />
+              <thirdPartyError />
+              <thirdPartySubError />
+            </status>
+            <transactionStatus>0</transactionStatus>
+            <transactionRef>8f1e5d836a344d06874ab205978e54dd</transactionRef>
+            <transactionNumber>16207900</transactionNumber>
+            <pending>false</pending>
+            <orderId>ORDERID1000</orderId>
+            <productId>PRODUCTNUMBER1000</productId>
+            <paymentMethod>INVOICE</paymentMethod>
+            <productNumber>PRODUCTNUMBER1000</productNumber>
+          </payex>
+        ]]>
+      </PurchaseInvoicePrivateResult>
+    </PurchaseInvoicePrivateResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/payex_spec.rb
+++ b/spec/payex_spec.rb
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+require 'payex'
+require 'spec_helper'
+require 'savon/mock/spec_helper'
+
+describe PayEx do
+  include Savon::SpecHelper
+
+  before(:all) { savon.mock!   }
+  after(:all)  { savon.unmock! }
+
+  describe :initialize! do
+    example 'successful initialization' do
+      expected = {
+        'accountNumber' => PAYEX_ACCOUNT_NUMBER,
+        'purchaseOperation' => 'AUTHORIZATION',
+        'price' => SAMPLE_PRICE_CENTS,
+        'priceArgList' => '',
+        'currency' => PAYEX_DEFAULT_CURRENCY,
+        'vat' => 0,
+        'orderID' => SAMPLE_ORDER_ID,
+        'productNumber' => SAMPLE_PRODUCT_NUMBER,
+        'description' => SAMPLE_PRODUCT_DESCRIPTION,
+        'clientIPAddress' => '12.34.56.78',
+        'clientIdentifier' => '',
+        'additionalValues' => 'RESPONSIVE=1',
+        'externalID' => '',
+        'returnUrl' => 'http://example.com/payex-return',
+        'view' => 'CREDITCARD',
+        'agreementRef' => '',
+        'cancelUrl' => 'http://example.com/payex-cancel',
+        'clientLanguage' => ''
+      }
+      expected['hash'] = PayEx::API.signed_hash(expected.values.join)
+
+      initialize_ok_fixture = File.read('spec/fixtures/initialize8/initialize_ok.xml')
+      savon.expects(:initialize8).with(message: expected).returns(initialize_ok_fixture)
+
+      href = PayEx.initialize!(
+        purchase_operation: expected.fetch('purchaseOperation'),
+        price: expected.fetch('price'),
+        order_id: expected.fetch('orderID'),
+        product_number: expected.fetch('productNumber'),
+        description: expected.fetch('description'),
+        client_ip_address: expected.fetch('clientIPAddress'),
+        return_url: expected.fetch('returnUrl'),
+        cancel_url: expected.fetch('cancelUrl')
+      )
+      href.should include :order_ref
+    end
+  end
+end

--- a/spec/redirect_spec.rb
+++ b/spec/redirect_spec.rb
@@ -9,78 +9,17 @@ describe PayEx::Redirect do
   before(:all) { savon.mock!   }
   after(:all)  { savon.unmock! }
 
-  SAMPLE_ACCOUNT_NUMBER = 'SAMPLEACCOUNTNUMBER0001'
-  SAMPLE_ENCRYPTION_KEY = 'SAMPLEENCRYPTIONKEY0001'
-  SAMPLE_DEFAULT_CURRENCY = 'SEK'
-
-  before {
-    PayEx.account_number = SAMPLE_ACCOUNT_NUMBER
-    PayEx.encryption_key = SAMPLE_ENCRYPTION_KEY
-    PayEx.default_currency = SAMPLE_DEFAULT_CURRENCY
-  }
-
-  SAMPLE_PRICE_CENTS = 12300
-  SAMPLE_ORDER_ID = 'SAMPLEORDERID0001'
-  SAMPLE_PRODUCT_NUMBER = 'SAMPLEPRODUCTNUMBER0001'
-  SAMPLE_PRODUCT_DESCRIPTION = 'Sample product description 0001'
-  SAMPLE_IP_ADDRESS = '12.34.56.78'
-  SAMPLE_RETURN_URL = 'http://example.com/payex-return'
-  SAMPLE_CANCEL_URL = 'http://example.com/payex-cancel'
-
-  describe :initialize! do
-    example 'successful initialization' do
-      expected = {
-        'accountNumber' => SAMPLE_ACCOUNT_NUMBER,
-        'purchaseOperation' => 'AUTHORIZATION',
-        'price' => SAMPLE_PRICE_CENTS,
-        'priceArgList' => '',
-        'currency' => SAMPLE_DEFAULT_CURRENCY,
-        'vat' => 0,
-        'orderID' => SAMPLE_ORDER_ID,
-        'productNumber' => SAMPLE_PRODUCT_NUMBER,
-        'description' => SAMPLE_PRODUCT_DESCRIPTION,
-        'clientIPAddress' => SAMPLE_IP_ADDRESS,
-        'clientIdentifier' => '',
-        'additionalValues' => 'RESPONSIVE=1',
-        'externalID' => '',
-        'returnUrl' => SAMPLE_RETURN_URL,
-        'view' => 'CREDITCARD',
-        'agreementRef' => '',
-        'cancelUrl' => SAMPLE_CANCEL_URL,
-        'clientLanguage' => ''
-      }
-      expected['hash'] = PayEx::API.signed_hash(expected.values.join)
-
-      initialize_ok_fixture = File.read('spec/fixtures/initialize8/initialize_ok.xml')
-      savon.expects(:initialize8).with(message: expected).returns(initialize_ok_fixture)
-
-      href = PayEx::Redirect.initialize!(
-        purchase_operation: 'AUTHORIZATION',
-        price: SAMPLE_PRICE_CENTS,
-        order_id: SAMPLE_ORDER_ID,
-        product_number: SAMPLE_PRODUCT_NUMBER,
-        description: SAMPLE_PRODUCT_DESCRIPTION,
-        client_ip_address: SAMPLE_IP_ADDRESS,
-        return_url: SAMPLE_RETURN_URL,
-        cancel_url: SAMPLE_CANCEL_URL
-      )
-      href.should include 'http'
-    end
-  end
-
-  SAMPLE_ORDER_REF = 'SAMPLEORDERREF0001'
-
   describe :complete! do
     def invoke_complete! response_fixture_file
       expected = {
-        'accountNumber' => SAMPLE_ACCOUNT_NUMBER,
+        'accountNumber' => PAYEX_ACCOUNT_NUMBER,
         'orderRef' => SAMPLE_ORDER_REF
       }
 
       expected['hash'] = PayEx::API.signed_hash(expected.values.join)
       response_fixture = File.read("spec/fixtures/complete/#{response_fixture_file}.xml")
       savon.expects(:complete).with(message: expected).returns(response_fixture)
-      PayEx::Redirect.complete! SAMPLE_ORDER_REF
+      PayEx::Redirect.complete!(expected.fetch('orderRef'))
     end
 
     example 'successful completion' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,20 @@
 # Suppress "HTTPI executes HTTP GET using the httpclient adapter"
 HTTPI.log = false
+
+PAYEX_ACCOUNT_NUMBER = 'ACCOUNTNUMBER1000'
+PAYEX_ENCRYPTION_KEY = 'ENCRYPTIONKEY1000'
+PAYEX_DEFAULT_CURRENCY = 'SEK'
+
+SAMPLE_ORDER_REF = 'ORDERREF1000'
+SAMPLE_ORDER_ID = 'ORDERID1000'
+SAMPLE_PRODUCT_NUMBER = 'PRODUCTNUMBER1000'
+SAMPLE_PRODUCT_DESCRIPTION = 'Sample product description'
+SAMPLE_PRICE_CENTS = 12300
+
+RSpec.configure do |config|
+  config.before(:each) do
+    PayEx.account_number = PAYEX_ACCOUNT_NUMBER
+    PayEx.encryption_key = PAYEX_ENCRYPTION_KEY
+    PayEx.default_currency = PAYEX_DEFAULT_CURRENCY
+  end
+end


### PR DESCRIPTION
@alex-ross är lite osäker på om `ssl_verify_mode: : none` är en bra idé men det fungerar inte annars. Har du någon bättre alternativ lösning?